### PR TITLE
Update reviewer config to reviewers with activity in repo areas

### DIFF
--- a/.github/REVIEWERS.yml
+++ b/.github/REVIEWERS.yml
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 labels:
-- name: "Go"
-  reviewers: ["damccorm", "dannymccormick3", "damccormNotACommitter"]
-  exclusionList: [] # These users will never be suggested as reviewers
-# I don't know the other areas well enough to assess who the normal committers/contributors who might want to be reviewers are
-fallbackReviewers: [] # List of committers to use when no label matches
+  - name: Go
+    reviewers:
+      - damccorm
+    exclusionList: []
+fallbackReviewers: []


### PR DESCRIPTION
Adds and/or removes reviewers based on activity in the repo.

If you have been added and would prefer not to be, you can avoid getting repeatedly suggested by adding yourself to that label's exclusionList.

The following users have been removed as reviewers from the configuration.
Users are removed if they haven't reviewed or completed a PR in the last 3 months.

@dannymccormick3 added for label(s): go
@damccormNotACommitter added for label(s): go
